### PR TITLE
M3 fix

### DIFF
--- a/src/lang/cpp/M3.rsc
+++ b/src/lang/cpp/M3.rsc
@@ -153,31 +153,31 @@ rel[loc, loc] makeEntry(Declaration declaration, loc current) {
   }
 }
 
-M3 createM3FromCFile(loc file, list[loc] stdLib = [], list[loc] includeDirs = [], map[str,str] additionalMacros = (), bool includeStdLib = false) {
-  tuple[M3,Declaration] m3AndAst = parseCToM3AndAst(file, stdLib = stdLib, includeDirs = includeDirs, additionalMacros = additionalMacros, includeStdLib = includeStdLib);
+M3 createM3FromCFile(loc file, list[loc] stdLib = [], list[loc] includeDirs = [], map[str,str] standardMacros = (), map[str,str] additionalMacros = (), bool includeStdLib = false) {
+  tuple[M3,Declaration] m3AndAst = parseCToM3AndAst(file, stdLib = stdLib, includeDirs = includeDirs, standardMacros = standardMacros, additionalMacros = additionalMacros, includeStdLib = includeStdLib);
   return cppASTToM3(m3AndAst<1>, model = m3AndAst<0>);
 }
 
-M3 createM3FromCppFile(loc file, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] additionalMacros = (), bool includeStdLib = false) {
-  tuple[M3,Declaration] m3AndAst = parseCppToM3AndAst(file, stdLib = stdLib, includeDirs = includeDirs, additionalMacros = additionalMacros, includeStdLib = includeStdLib);
+M3 createM3FromCppFile(loc file, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] standardMacros = (), map[str,str] additionalMacros = (), bool includeStdLib = false) {
+  tuple[M3,Declaration] m3AndAst = parseCppToM3AndAst(file, stdLib = stdLib, includeDirs = includeDirs, standardMacros = standardMacros, additionalMacros = additionalMacros, includeStdLib = includeStdLib);
   return cppASTToM3(m3AndAst<1>, model = m3AndAst<0>);
 }
 
-tuple[M3, Declaration] createM3AndAstFromCFile(loc file, list[loc] stdLib = [], list[loc] includeDirs = [], map[str,str] additionalMacros = (), bool includeStdLib = false) {
-  tuple[M3,Declaration] m3AndAst = parseCToM3AndAst(file, stdLib = stdLib, includeDirs = includeDirs, additionalMacros = additionalMacros, includeStdLib = includeStdLib);
+tuple[M3, Declaration] createM3AndAstFromCFile(loc file, list[loc] stdLib = [], list[loc] includeDirs = [], map[str,str] standardMacros = (), map[str,str] additionalMacros = (), bool includeStdLib = false) {
+  tuple[M3,Declaration] m3AndAst = parseCToM3AndAst(file, stdLib = stdLib, includeDirs = includeDirs, standardMacros = standardMacros, additionalMacros = additionalMacros, includeStdLib = includeStdLib);
   return <cppASTToM3(m3AndAst<1>, model = m3AndAst<0>),m3AndAst<1>>;
 }
 
-tuple[M3, Declaration] createM3AndAstFromCppFile(loc file, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] additionalMacros = (), bool includeStdLib = false) {
-  tuple[M3,Declaration] m3AndAst = parseCppToM3AndAst(file, stdLib = stdLib, includeDirs = includeDirs, additionalMacros = additionalMacros, includeStdLib = includeStdLib);
+tuple[M3, Declaration] createM3AndAstFromCppFile(loc file, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] standardMacros = (), map[str,str] additionalMacros = (), bool includeStdLib = false) {
+  tuple[M3,Declaration] m3AndAst = parseCppToM3AndAst(file, stdLib = stdLib, includeDirs = includeDirs, standardMacros = standardMacros, additionalMacros = additionalMacros, includeStdLib = includeStdLib);
   return <cppASTToM3(m3AndAst<1>, model = m3AndAst<0>),m3AndAst<1>>;
 }
 
 @javaClass{lang.cpp.internal.Parser}
-java tuple[M3, Declaration] parseCppToM3AndAst(loc file, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] additionalMacros = (), bool includeStdLib = false);
+java tuple[M3, Declaration] parseCppToM3AndAst(loc file, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] standardMacros = (), map[str,str] additionalMacros = (), bool includeStdLib = false);
 
 @javaClass{lang.cpp.internal.Parser}
-java tuple[M3, Declaration] parseCToM3AndAst(loc file, list[loc] stdLib = [], list[loc] includeDirs = [], map[str,str] additionalMacros = (), bool includeStdLib = false);
+java tuple[M3, Declaration] parseCToM3AndAst(loc file, list[loc] stdLib = [], list[loc] includeDirs = [], map[str,str] standardMacros = (), map[str,str] additionalMacros = (), bool includeStdLib = false);
 
 M3 composeCppM3(loc id, set[M3] models) {
   M3 comp = composeM3(id, models); 

--- a/src/lang/cpp/M3.rsc
+++ b/src/lang/cpp/M3.rsc
@@ -153,31 +153,31 @@ rel[loc, loc] makeEntry(Declaration declaration, loc current) {
   }
 }
 
-M3 createM3FromCFile(loc file, list[loc] stdLib = [], list[loc] includeDirs = [], map[str,str] standardMacros = (), map[str,str] additionalMacros = (), bool includeStdLib = false) {
+M3 createM3FromCFile(loc file, list[loc] stdLib = [], list[loc] includeDirs = [], map[str,str] standardMacros = provideStandardMacros(), map[str,str] additionalMacros = (), bool includeStdLib = false) {
   tuple[M3,Declaration] m3AndAst = parseCToM3AndAst(file, stdLib = stdLib, includeDirs = includeDirs, standardMacros = standardMacros, additionalMacros = additionalMacros, includeStdLib = includeStdLib);
   return cppASTToM3(m3AndAst<1>, model = m3AndAst<0>);
 }
 
-M3 createM3FromCppFile(loc file, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] standardMacros = (), map[str,str] additionalMacros = (), bool includeStdLib = false) {
+M3 createM3FromCppFile(loc file, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] standardMacros = provideStandardMacros(), map[str,str] additionalMacros = (), bool includeStdLib = false) {
   tuple[M3,Declaration] m3AndAst = parseCppToM3AndAst(file, stdLib = stdLib, includeDirs = includeDirs, standardMacros = standardMacros, additionalMacros = additionalMacros, includeStdLib = includeStdLib);
   return cppASTToM3(m3AndAst<1>, model = m3AndAst<0>);
 }
 
-tuple[M3, Declaration] createM3AndAstFromCFile(loc file, list[loc] stdLib = [], list[loc] includeDirs = [], map[str,str] standardMacros = (), map[str,str] additionalMacros = (), bool includeStdLib = false) {
+tuple[M3, Declaration] createM3AndAstFromCFile(loc file, list[loc] stdLib = [], list[loc] includeDirs = [], map[str,str] standardMacros = provideStandardMacros(), map[str,str] additionalMacros = (), bool includeStdLib = false) {
   tuple[M3,Declaration] m3AndAst = parseCToM3AndAst(file, stdLib = stdLib, includeDirs = includeDirs, standardMacros = standardMacros, additionalMacros = additionalMacros, includeStdLib = includeStdLib);
   return <cppASTToM3(m3AndAst<1>, model = m3AndAst<0>),m3AndAst<1>>;
 }
 
-tuple[M3, Declaration] createM3AndAstFromCppFile(loc file, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] standardMacros = (), map[str,str] additionalMacros = (), bool includeStdLib = false) {
+tuple[M3, Declaration] createM3AndAstFromCppFile(loc file, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] standardMacros = provideStandardMacros(), map[str,str] additionalMacros = (), bool includeStdLib = false) {
   tuple[M3,Declaration] m3AndAst = parseCppToM3AndAst(file, stdLib = stdLib, includeDirs = includeDirs, standardMacros = standardMacros, additionalMacros = additionalMacros, includeStdLib = includeStdLib);
   return <cppASTToM3(m3AndAst<1>, model = m3AndAst<0>),m3AndAst<1>>;
 }
 
 @javaClass{lang.cpp.internal.Parser}
-java tuple[M3, Declaration] parseCppToM3AndAst(loc file, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] standardMacros = (), map[str,str] additionalMacros = (), bool includeStdLib = false);
+java tuple[M3, Declaration] parseCppToM3AndAst(loc file, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] standardMacros = provideStandardMacros(), map[str,str] additionalMacros = (), bool includeStdLib = false);
 
 @javaClass{lang.cpp.internal.Parser}
-java tuple[M3, Declaration] parseCToM3AndAst(loc file, list[loc] stdLib = [], list[loc] includeDirs = [], map[str,str] standardMacros = (), map[str,str] additionalMacros = (), bool includeStdLib = false);
+java tuple[M3, Declaration] parseCToM3AndAst(loc file, list[loc] stdLib = [], list[loc] includeDirs = [], map[str,str] standardMacros = provideStandardMacros(), map[str,str] additionalMacros = (), bool includeStdLib = false);
 
 M3 composeCppM3(loc id, set[M3] models) {
   M3 comp = composeM3(id, models); 


### PR DESCRIPTION
After making the default macros a keyword argument, the functions in the M3 were still using the old signature, which caused clair to fail.
This push request updates the signatures and fixes the bug.