### PR TITLE
make paths with spaces correctly processed by pretty()

### DIFF
--- a/src/lang/cpp/M3.rsc
+++ b/src/lang/cpp/M3.rsc
@@ -98,7 +98,7 @@ rel[loc caller, loc callee] extractCallGraph(set[Declaration] asts)
   = { <caller.declarator.decl, c.decl> | ast <- asts, /Declaration caller := ast, caller has declarator, /Expression c := caller, c has decl,
       c.decl.scheme notin {"cpp+class", "cpp+enumerator", "cpp+field", "cpp+parameter", "cpp+typedef", "cpp+variable", "c+variable", "unknown", "cpp+unknown"} };		//Over-approximation
 
-loc pretty(loc subject) = |<subject.scheme>://<pretty(subject.path)>|;
+loc pretty(loc subject) = |<subject.scheme>:///| + pretty(subject.path);
 str pretty(str path) = replaceAll(path, "\\", "/");
 
 loc loseCArgs(loc subject) = subject.scheme=="c+function"?|c+function://<loseCArgs(subject.path)>|:subject;


### PR DESCRIPTION
The `pretty(loc subject)` function cannot process the directory with spaces:
```
rascal>loc path = |file:///| + "C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um";
loc: |file:///C:/Program%20Files%20(x86)/Windows%20Kits/10/Include/10.0.19041.0/um|
rascal>pretty(path)
|lib://clair/src/lang/cpp/M3.rsc|(6026,43,<101,26>,<101,69>): MalFormedURI("file:///C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um")
        at pretty(|lib://clair/src/lang/cpp/M3.rsc|(6000,70,<101,0>,<101,70>))
        at $shell$(|prompt:///|(0,21,<1,0>,<1,21>)ok
```
This pull request is to fix this problem.